### PR TITLE
SVG export as a Grapher option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,24 +1,26 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>ca.intelliware.commons</groupId>
-	<artifactId>dependency-graph</artifactId>
-	<packaging>jar</packaging>
-	<version>1.2-SNAPSHOT</version>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ca.intelliware.commons</groupId>
+    <artifactId>dependency-graph</artifactId>
+    <packaging>jar</packaging>
+    <version>2.0-SNAPSHOT</version>
 
-	<name>dependency-graph</name>
+    <name>dependency-graph</name>
 
-	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>ca.intelliware.commons</groupId>
             <artifactId>dependency</artifactId>
-            <version>1.3-SNAPSHOT</version>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -27,26 +29,26 @@
             <version>2.3</version>
         </dependency>
 
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>2.28.2</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>jdepend</groupId>
-			<artifactId>jdepend</artifactId>
-			<version>2.9.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>jdepend</groupId>
+            <artifactId>jdepend</artifactId>
+            <version>2.9.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <version>2.3</version>
         </dependency>
 
+		<dependency>
+		    <groupId>commons-io</groupId>
+		    <artifactId>commons-io</artifactId>
+		    <version>2.18.0</version>
+		</dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/ca/intelliware/commons/dependency/graph/Arrow.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/Arrow.java
@@ -16,9 +16,15 @@ class Arrow {
 	private static final double NINETY_DEGREES_IN_RADIANS = PI / 2.0;
 	private static final double ONE_EIGHTY_DEGREES_IN_RADIANS = PI;
 	private List<Point2D> points;
+	private float width;
 	
 	Arrow(List<Point2D> points) {
+		this(points, 1.0f);
+	}
+
+	Arrow(List<Point2D> points, float width) {
 		this.points = points;
+		this.width = width;
 	}
 
 	List<Point2D> getPoints() {
@@ -121,5 +127,13 @@ class Arrow {
 		List<Point2D> points = new ArrayList<Point2D>(this.points.subList(1, this.points.size()));
 		points.add(0, to);
 		return new Arrow(points);
+	}
+
+	public float getWidth() {
+		return this.width;
+	}
+
+	public void setWidth(float width) {
+		this.width = width;
 	}
 }

--- a/src/main/java/ca/intelliware/commons/dependency/graph/ArrowShape.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/ArrowShape.java
@@ -5,6 +5,7 @@ import static java.awt.RenderingHints.VALUE_ANTIALIAS_ON;
 
 import java.awt.BasicStroke;
 import java.awt.Graphics2D;
+import java.awt.Stroke;
 import java.awt.geom.GeneralPath;
 
 class ArrowShape {
@@ -19,16 +20,31 @@ class ArrowShape {
 		} else {
 			graphics.setColor(this.plot.getArrowColor());
 		}
-		graphics.setStroke(this.plot.getArrowStroke());
+		Stroke stroke = this.plot.getArrowStroke();
+		if (stroke instanceof BasicStroke) {
+			BasicStroke basicStroke = (BasicStroke) stroke;
+			stroke = new BasicStroke(basicStroke.getLineWidth() * arrow.getWidth(), basicStroke.getEndCap(), 
+					basicStroke.getLineJoin(), basicStroke.getMiterLimit(), adjustDashes(basicStroke.getDashArray(), arrow.getWidth()), basicStroke.getDashPhase());
+		}
+		graphics.setStroke(stroke);
 		graphics.draw(arrow.toShape());
 		
 		drawArrowHead(graphics, arrow);
 	}
 
+	private float[] adjustDashes(float[] dashArray, float width) {
+		float[] result = new float[dashArray.length];
+		for (int i = 0; i < dashArray.length; i++) {
+			result[i] = dashArray[i] * width;
+		}
+		return result;
+	}
+
 	protected void drawArrowHead(Graphics2D graphics, Arrow arrow) {
 		graphics = (Graphics2D) graphics.create();
 		try {
-			graphics.setStroke(new BasicStroke());
+			BasicStroke stroke = new BasicStroke();
+			graphics.setStroke(new BasicStroke(stroke.getLineWidth() * arrow.getWidth()));
 			graphics.translate(arrow.getLastPoint().getX(), arrow.getLastPoint().getY());
 			
 			graphics.rotate(arrow.getAngleOfLastSegment());

--- a/src/main/java/ca/intelliware/commons/dependency/graph/ArrowShape.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/ArrowShape.java
@@ -7,6 +7,9 @@ import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
 import java.awt.geom.GeneralPath;
+import java.awt.geom.Point2D;
+import java.io.IOException;
+import java.io.OutputStream;
 
 class ArrowShape {
 	
@@ -65,5 +68,32 @@ class ArrowShape {
 
 	public void setPlot(Plot plot) {
 		this.plot = plot;
+	}
+
+	public void drawArrowSvg(OutputStream output, Arrow arrow) throws IOException {
+		/*
+		 * <marker xmlns="http://www.w3.org/2000/svg" style="overflow:visible" id="ArrowWide" refX="0" refY="0" orient="auto-start-reverse" inkscape:stockid="Wide arrow" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" markerWidth="1" markerHeight="1" viewBox="0 0 1 1" inkscape:isstock="true" inkscape:collect="always" preserveAspectRatio="xMidYMid"><path style="fill:none;stroke:context-stroke;stroke-width:1;stroke-linecap:butt" d="M 3,-3 0,0 3,3" transform="rotate(180,0.125,0)" sodipodi:nodetypes="ccc" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" id="path3"/></marker>
+		 */
+		
+		
+		String strokeColour = HtmlColor.asHtml(this.plot.getArrowColor());
+		if (arrow.isPointingUpward()) {
+			strokeColour = HtmlColor.asHtml(this.plot.getReverseArrowColor());
+		}
+
+		String instruction = "M ";
+		String path = "";
+		for (Point2D p : arrow.getPoints()) {
+			path += instruction + p.getX() + " " + p.getY() + " ";
+			instruction = "L ";
+		}
+		output.write(("<marker style=\"overflow:visible\" id=\"ArrowWide-" + path.hashCode() 
+			+ "\" refX=\"0\" refY=\"0\" orient=\"auto-start-reverse\" markerWidth=\"1\" markerHeight=\"1\" viewBox=\"0 0 1 1\" "
+			+ "preserveAspectRatio=\"xMidYMid\">").getBytes("UTF-8"));
+		output.write(("<path style=\"fill:none;stroke:context-stroke;stroke-width:" + arrow.getWidth() 
+			+ ";stroke-linecap:butt\" d=\"M 5,-5 0,0 5,5\" transform=\"rotate(180,0.125,0)\" />").getBytes("UTF-8"));
+		output.write(("</marker>").getBytes("UTF-8"));
+		output.write(("<path d=\"" + path +  "\" stroke-width=\"" + arrow.getWidth() + "\" stroke=\"" 
+				+ strokeColour + "\" fill=\"none\" stroke-dasharray=\"8 5\" marker-end=\"url(#ArrowWide-" + path.hashCode() + "\" />").getBytes());
 	}
 }

--- a/src/main/java/ca/intelliware/commons/dependency/graph/Graph.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/Graph.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
+import ca.intelliware.commons.dependency.Coupling;
 import ca.intelliware.commons.dependency.DependencyManager;
 import ca.intelliware.commons.dependency.Layer;
 import ca.intelliware.commons.dependency.Node;
@@ -45,7 +47,8 @@ class Graph implements SugiyamaGraph {
 				return false;
 			} else if (vertex instanceof BasicVertex) {
 				Object object = ((BasicVertex) vertex).node.getItem();
-				return this.node.getAfferentCouplings().contains(object) || this.node.getEfferentCouplings().contains(object);
+				return this.node.getAfferentCouplings().stream().map(c -> c.getItem()).collect(Collectors.toList()).contains(object) 
+						|| this.node.getEfferentCouplings().stream().map(c -> c.getItem()).collect(Collectors.toList()).contains(object);
 			} else {
 				return vertex.isNeighbour(this);
 			}
@@ -112,8 +115,8 @@ class Graph implements SugiyamaGraph {
 	}
 
 	private static <T> void createDummyVertices(Map<Object, Vertex> map, Node<T> node, Vertex top, Graph graph) {
-		for (Object dependency : node.getEfferentCouplings()) {
-			Vertex bottom = map.get(dependency);
+		for (Coupling<?> dependency : node.getEfferentCouplings()) {
+			Vertex bottom = map.get(dependency.getItem());
 			if (node.getLayer() - bottom.getLayer() > 1) {
 				createDummyVertices(node.getLayer(), top, bottom, graph);
 			} else if (bottom.getLayer() - node.getLayer() > 1) {

--- a/src/main/java/ca/intelliware/commons/dependency/graph/HorizontalCoordinateAssignmentAlgorithm.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/HorizontalCoordinateAssignmentAlgorithm.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import ca.intelliware.commons.dependency.Coupling;
 import ca.intelliware.commons.dependency.DependencyManager;
 import ca.intelliware.commons.dependency.LayeredGraph;
 import ca.intelliware.commons.dependency.Node;
@@ -121,13 +122,13 @@ class HorizontalCoordinateAssignmentAlgorithm {
 		for (Node<Block> node : layeredGraph.getNodes()) {
 			Block block = node.getItem();
 			if (block.getCluster() == cluster) {
-				for (Block afferent : node.getAfferentCouplings()) {
-					if (afferent.getCluster() == cluster) {
+				for (Coupling<Block> afferent : node.getAfferentCouplings()) {
+					if (afferent.getItem().getCluster() == cluster) {
 						// ignore it
-					} else if (afferent.getCluster().isAssigned()) {
+					} else if (afferent.getItem().getCluster().isAssigned()) {
 						shift = Math.min(shift, 
-								afferent.getHorizontalCoordinate() 
-									- block.getRelativeHorizontalCoordinate() - Block.minimumDistance(afferent, block));
+								afferent.getItem().getHorizontalCoordinate() 
+									- block.getRelativeHorizontalCoordinate() - Block.minimumDistance(afferent.getItem(), block));
 					} else {
 						throw new RuntimeException("Warning!  Expected cluster to be assigned a shift value");
 					}
@@ -150,9 +151,9 @@ class HorizontalCoordinateAssignmentAlgorithm {
 			Block block = node.getItem();
 			if (block.getCluster() == cluster) {
 				dependencyManager.add(block);
-				for (Block afferent : node.getAfferentCouplings()) {
-					if (afferent.getCluster() == cluster) {
-						dependencyManager.add(afferent, block);
+				for (Coupling<Block> afferent : node.getAfferentCouplings()) {
+					if (afferent.getItem().getCluster() == cluster) {
+						dependencyManager.add(afferent.getItem(), block);
 					}						
 				}
 			}
@@ -175,8 +176,8 @@ class HorizontalCoordinateAssignmentAlgorithm {
 				block.assignCluster(cluster);
 				clusters.add(cluster);
 			} else {
-				for (Block efferent : node.getEfferentCouplings()) {
-					block.assignCluster(efferent.getCluster());
+				for (Coupling<Block> efferent : node.getEfferentCouplings()) {
+					block.assignCluster(efferent.getItem().getCluster());
 				}
 			}
 		}

--- a/src/main/java/ca/intelliware/commons/dependency/graph/HtmlColor.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/HtmlColor.java
@@ -1,0 +1,17 @@
+package ca.intelliware.commons.dependency.graph;
+
+import java.awt.Color;
+
+public class HtmlColor {
+
+	public static String asHtml(Color color) {
+	    String red = Integer.toHexString(color.getRed());
+	    String green = Integer.toHexString(color.getGreen());
+	    String blue = Integer.toHexString(color.getBlue());
+
+	    return "#" + 
+	            (red.length() == 1? "0" + red : red) +
+	            (green.length() == 1? "0" + green : green) +
+	            (blue.length() == 1? "0" + blue : blue);        
+	}
+}

--- a/src/main/java/ca/intelliware/commons/dependency/graph/NodeShape.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/NodeShape.java
@@ -50,6 +50,9 @@ public class NodeShape<T> {
 		outputStream.write(("<rect x=\"" + (upperLeft.getX()) + "\" y=\"" + (upperLeft.getY()) + "\" height=\"" 
 				+ this.dimension.getHeight() + "\" width=\"" + this.dimension.getWidth() + "\" fill=\"" 
 				+ shapeFill + "\" stroke=\"" + shapeStroke + "\" stroke-width=\"1\"  />").getBytes("UTF-8"));
+		
+		this.drawStringSvg(node.getName(), getWidth() / 2.0 + upperLeft.getX(), getHeight() / 2.0 + upperLeft.getY(), outputStream);
+
 	}
 	
 	protected void draw(Graphics2D graphics, Node<T> node) {

--- a/src/main/java/ca/intelliware/commons/dependency/graph/shape/BigPackageShape.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/shape/BigPackageShape.java
@@ -5,6 +5,9 @@ import static ca.intelliware.commons.dependency.graph.shape.CommonImage.PACKAGE_
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
+import java.awt.geom.Point2D;
+import java.io.IOException;
+import java.io.OutputStream;
 
 import javax.swing.ImageIcon;
 
@@ -23,6 +26,16 @@ public class BigPackageShape<T> extends PackageShape<T> {
 		graphics.drawImage(getPackageImage().getImage(), (int) x, 0, null);
 		graphics.setColor(getPlot().getShapeLineColor());
 		drawNodeName(graphics, node);
+	}
+
+	@Override
+	protected void drawSvg(Node<T> node, Point2D upperLeft, OutputStream outputStream) throws IOException {
+		double x = (getWidth() - getPackageImage().getIconWidth()) / 2.0;
+		
+		outputStream.write(("<image x=\"" + (upperLeft.getX() + x) + "\" y=\"" + upperLeft.getY() + "\" href=\"data:image/png;base64," + PACKAGE_BIG_ICON.getBase64EncodedImage() + "\" /> ").getBytes("UTF-8"));
+		
+		double y = getHeight() / 2.0 + getPackageImage().getIconHeight() / 2.0;
+		this.drawStringSvg(node.getName(), getWidth() / 2.0 + upperLeft.getX(), y + upperLeft.getY(), outputStream);
 	}
 	
 	@Override

--- a/src/main/java/ca/intelliware/commons/dependency/graph/shape/CommonImage.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/shape/CommonImage.java
@@ -1,6 +1,14 @@
 package ca.intelliware.commons.dependency.graph.shape;
 
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Base64;
+
+import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
+
+import org.apache.commons.io.IOUtils;
 
 
 public enum CommonImage implements ImageProvider {
@@ -10,6 +18,7 @@ public enum CommonImage implements ImageProvider {
 
 	private final String resourceName;
 	private ImageIcon image;
+	private BufferedImage bufferedImage;
 
 	private CommonImage(String resourceName) {
 		this.resourceName = resourceName;
@@ -20,5 +29,18 @@ public enum CommonImage implements ImageProvider {
 			this.image = new ImageIcon(getClass().getResource(this.resourceName));
 		}
 		return this.image;
+	}
+
+	BufferedImage getBufferedImage() throws IOException {
+		if (this.bufferedImage == null) {
+			this.bufferedImage = ImageIO.read(getClass().getResource(this.resourceName));
+		}
+		return this.bufferedImage;
+	}
+	
+	String getBase64EncodedImage() throws IOException {
+		try (InputStream input = getClass().getResourceAsStream(this.resourceName)) {
+			return Base64.getEncoder().encodeToString(IOUtils.toByteArray(input));
+		}
 	}
 }

--- a/src/main/java/ca/intelliware/commons/dependency/graph/shape/PackageShape.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/shape/PackageShape.java
@@ -82,7 +82,8 @@ public class PackageShape<T> extends NodeShape<T> {
 	public void initialize(Graphics2D graphics, List<Node<T>> nodes) {
 		this.prefix = getPackageNamePrefix(nodes);
 		
-		FontMetrics metrics = graphics.getFontMetrics();
+		Font font = new Font("Helvetica", Font.PLAIN, 10);
+		FontMetrics metrics = graphics.getFontMetrics(font);
 		Rectangle2D bounds = metrics.getStringBounds(this.prefix.toString() + ".", graphics);
 		double width = bounds.getWidth();
 		for (Node<T> node : nodes) {
@@ -93,7 +94,6 @@ public class PackageShape<T> extends NodeShape<T> {
 		
 		double ratio = Math.max(1.0, width / getTextAreaWidth());
 		
-		Font font = graphics.getFont();
 		AffineTransform transform = new AffineTransform();
 		transform.scale(1.00 / ratio, 1.0 / ratio);
 		setFont(font.deriveFont(transform));

--- a/src/main/java/ca/intelliware/commons/dependency/graph/shape/PackageShape.java
+++ b/src/main/java/ca/intelliware/commons/dependency/graph/shape/PackageShape.java
@@ -10,6 +10,8 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 
 import javax.swing.ImageIcon;
@@ -17,11 +19,13 @@ import javax.swing.ImageIcon;
 import org.apache.commons.lang.StringUtils;
 
 import ca.intelliware.commons.dependency.Node;
+import ca.intelliware.commons.dependency.graph.HtmlColor;
 import ca.intelliware.commons.dependency.graph.NodeShape;
 
 public class PackageShape<T> extends NodeShape<T> {
 	
 	private PackageName prefix;
+	private float fontHeight;
 
 	public PackageShape() {
 		setDimension(new Dimension(150, 75));
@@ -44,6 +48,43 @@ public class PackageShape<T> extends NodeShape<T> {
 		
 		graphics.drawImage(getPackageImage().getImage(), (int) 2, 2, null);
 		drawNodeName(graphics, node);
+	}
+	
+	protected void drawSvg(Node<T> node, Point2D upperLeft, OutputStream outputStream) throws IOException {
+		
+		String shadowFill = HtmlColor.asHtml(getPlot().getShadowColor());
+		String shapeFill = HtmlColor.asHtml(getPlot().getShapeFillColor());
+		String shapeStroke = HtmlColor.asHtml(getPlot().getShapeLineColor());
+
+		double height = 20.0;
+		outputStream.write(("<rect x=\"" + (upperLeft.getX() + 3) + "\" y=\"" + (upperLeft.getY() + 3) + "\" height=\"" 
+				+ height + "\" width=\"" + (getDimension().getWidth() / 3.0) + "\" fill=\"" + shadowFill + "\" />").getBytes("UTF-8"));
+		outputStream.write(("<rect x=\"" + (upperLeft.getX() + 3) + "\" y=\"" + (upperLeft.getY() + 3  + height) + "\" height=\"" 
+				+ (getDimension().getHeight() - height) + "\" width=\"" + getDimension().getWidth() + "\" fill=\"" 
+				+ shadowFill + "\" />").getBytes("UTF-8"));
+		outputStream.write(("<rect x=\"" + (upperLeft.getX()) + "\" y=\"" + upperLeft.getY() + "\" height=\"" 
+				+ height + "\" width=\"" + (getDimension().getWidth() / 3.0) + "\" fill=\"" 
+				+ shapeFill + "\" stroke=\"" + shapeStroke + "\" stroke-width=\"1\"  />").getBytes("UTF-8"));
+		outputStream.write(("<rect x=\"" + (upperLeft.getX()) + "\" y=\"" + (upperLeft.getY() + height) + "\" height=\"" 
+				+ (getDimension().height - height) + "\" width=\"" + getDimension().getWidth() + "\" fill=\"" 
+				+ shapeFill + "\" stroke=\"" + shapeStroke + "\" stroke-width=\"1\"  />").getBytes("UTF-8"));
+		
+		outputStream.write(("<image x=\"" + (upperLeft.getX() + 3) + "\" y=\"" + (upperLeft.getY() + 2) + "\" href=\"data:image/png;base64," + PACKAGE_ICON.getBase64EncodedImage() + "\" /> ").getBytes("UTF-8"));
+
+		
+		PackageName packageName = new PackageName(node.getName());
+		if (StringUtils.isBlank(this.prefix.toString()) || this.prefix.equals(packageName)) {
+			this.drawStringSvg(node.getName(), getWidth() / 2.0 + upperLeft.getX(), getHeight() / 2.0 + upperLeft.getY(), outputStream);
+		} else {
+			this.drawStringSvg(this.prefix.toString() + ".", 
+					getWidth() / 2.0 + upperLeft.getX(), 
+					getHeight() / 2.0 - this.fontHeight / 2.0 + upperLeft.getY() + getPackageImage().getIconHeight() / 2.0, 
+					outputStream);
+			this.drawStringSvg(packageName.removePrefix(this.prefix).toString(), 
+					getWidth() / 2.0 + upperLeft.getX(), 
+					getHeight() / 2.0 + this.fontHeight / 2.0 + upperLeft.getY() + getPackageImage().getIconHeight() / 2.0, 
+					outputStream);
+		}
 	}
 
 	protected ImageIcon getPackageImage() {
@@ -97,6 +138,7 @@ public class PackageShape<T> extends NodeShape<T> {
 		AffineTransform transform = new AffineTransform();
 		transform.scale(1.00 / ratio, 1.0 / ratio);
 		setFont(font.deriveFont(transform));
+		this.fontHeight = metrics.getHeight();
 	}
 
 	private PackageName getPackageNamePrefix(List<Node<T>> nodes) {

--- a/src/test/java/ca/intelliware/commons/dependency/graph/BlockTest.java
+++ b/src/test/java/ca/intelliware/commons/dependency/graph/BlockTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BlockTest {

--- a/src/test/java/ca/intelliware/commons/dependency/graph/ClusterTest.java
+++ b/src/test/java/ca/intelliware/commons/dependency/graph/ClusterTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterTest {

--- a/src/test/java/ca/intelliware/commons/dependency/graph/CoordinateSystemTest.java
+++ b/src/test/java/ca/intelliware/commons/dependency/graph/CoordinateSystemTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CoordinateSystemTest {

--- a/src/test/java/ca/intelliware/commons/dependency/graph/shape/ComplicatedPackageGraphCrossings.java
+++ b/src/test/java/ca/intelliware/commons/dependency/graph/shape/ComplicatedPackageGraphCrossings.java
@@ -284,5 +284,14 @@ public class ComplicatedPackageGraphCrossings {
 		} finally {
 			output.close();
 		}
+		
+		File svg = new File(SystemUtils.JAVA_IO_TMPDIR, "ComplicatedPackageGraphCrossings.svg");
+		System.out.println(svg.getAbsolutePath());
+		try (OutputStream outputSvg = new FileOutputStream(svg)) {
+			Grapher<String> grapher = new Grapher<String>(manager);
+			grapher.setShape(new BigPackageShape<String>());
+			grapher.createSvg(outputSvg);
+		}
+
 	}
 }

--- a/src/test/java/ca/intelliware/commons/dependency/graph/shape/ComplicatedPackageGraphCrossings.java
+++ b/src/test/java/ca/intelliware/commons/dependency/graph/shape/ComplicatedPackageGraphCrossings.java
@@ -289,7 +289,7 @@ public class ComplicatedPackageGraphCrossings {
 		System.out.println(svg.getAbsolutePath());
 		try (OutputStream outputSvg = new FileOutputStream(svg)) {
 			Grapher<String> grapher = new Grapher<String>(manager);
-			grapher.setShape(new BigPackageShape<String>());
+			grapher.setShape(new PackageShape<String>());
 			grapher.createSvg(outputSvg);
 		}
 

--- a/src/test/java/ca/intelliware/commons/dependency/graph/shape/PackageGraphWithCrossings.java
+++ b/src/test/java/ca/intelliware/commons/dependency/graph/shape/PackageGraphWithCrossings.java
@@ -26,13 +26,18 @@ public class PackageGraphWithCrossings {
 
 		File file = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithCrossings.png");
 		System.out.println(file.getAbsolutePath());
-		OutputStream output = new FileOutputStream(file);
-		try {
+		try (OutputStream output = new FileOutputStream(file)) {
 			Grapher<String> grapher = new Grapher<String>(manager);
 			grapher.setShape(new BigPackageShape<String>());
 			grapher.createPng(output);
-		} finally {
-			output.close();
+		}
+		
+		File svg = new File(SystemUtils.JAVA_IO_TMPDIR, "PackageGraphWithCrossings.svg");
+		System.out.println(svg.getAbsolutePath());
+		try (OutputStream outputSvg = new FileOutputStream(svg)) {
+			Grapher<String> grapher = new Grapher<String>(manager);
+			grapher.setShape(new BigPackageShape<String>());
+			grapher.createSvg(outputSvg);
 		}
 	}
 }


### PR DESCRIPTION
Allow a user to export the dependency visual as an SVG rather than just PNG.